### PR TITLE
Fix dataset extraction and cleanup tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For custom tasks, you can reference the code in the `benchmark` folder. Inherit 
      --max_rounds 20        # Max iteration rounds for AFLOW
      --check_convergence    # Whether to enable early stop
      --validation_rounds 5  # Validation rounds for AFLOW
-     --if_first_optimize    # Set True for first optimization, False afterwards
+     --if_force_download    # Force dataset download if set to True
      ```
 
 3. Configure LLM parameters in `config/config2.yaml` (see `config/config2.example.yaml` for reference)

--- a/benchmarks/livecodebench.py
+++ b/benchmarks/livecodebench.py
@@ -22,7 +22,7 @@ from scripts.logs import logger
 import sys
 sys.path.append("..")
 sys.path.append("benchmarks")
-from scripts.utils.lcb_test import run_test  # 确保已安装lcb_runner
+from scripts.utils.lcb_runner import run_test  # 确保已安装lcb_runner
 
 # 从LiveCodeBench官方eval中复制的关键函数
 #sys.set_int_max_str_digits(50000)

--- a/scripts/operators.py
+++ b/scripts/operators.py
@@ -301,7 +301,7 @@ class Test(Operator):
     async def __call__(self, problem, solution, entry_point, test_loop: int = 3):
         """
         "Test": {
-        "description": "Test the solution with test cases, if the solution is correct, return 'no error', if the solution is incorrect, return reflect on the soluion and the error information",
+        "description": "Test the solution with test cases, if the solution is correct, return 'no error'; if incorrect, reflect on the solution and the error information",
         "interface": "test(problem: str, solution: str, entry_point: str) -> str"
         }
         """

--- a/scripts/utils/code.py
+++ b/scripts/utils/code.py
@@ -1,7 +1,7 @@
 import re
 import json
 from enum import Enum
-from typing import Any, List, Tuple
+from typing import Any, List, Tuple, Union
 
 
 class CodeDataset(Enum):
@@ -9,8 +9,13 @@ class CodeDataset(Enum):
     MBPP = "MBPP"
 
 
-def extract_test_cases_from_jsonl(entry_point: str, dataset: CodeDataset = CodeDataset.HUMAN_EVAL):
-    if dataset == CodeDataset.HUMAN_EVAL.value:
+def extract_test_cases_from_jsonl(entry_point: str, dataset: Union[CodeDataset, str] = CodeDataset.HUMAN_EVAL):
+    if isinstance(dataset, CodeDataset):
+        dataset_value = dataset.value
+    else:
+        dataset_value = dataset
+
+    if dataset_value == CodeDataset.HUMAN_EVAL.value:
         file_path = "data/datasets/humaneval_public_test.jsonl"
         # Retain the original hardcoded test cases
         hardcoded_cases = {
@@ -25,7 +30,7 @@ def extract_test_cases_from_jsonl(entry_point: str, dataset: CodeDataset = CodeD
             "sum_squares": "",
             "starts_one_ends": "",
         }
-    elif dataset == CodeDataset.MBPP.value:
+    elif dataset_value == CodeDataset.MBPP.value:
         file_path = "data/datasets/mbpp_public_test.jsonl"
         hardcoded_cases = {
             "remove_odd": "",

--- a/scripts/utils/lcb_runner.py
+++ b/scripts/utils/lcb_runner.py
@@ -399,9 +399,9 @@ def grade_stdio(
             if stripped_prediction_line == stripped_gt_out_line:
                 continue
 
-            ## CASE 2: element-wise comparision
+            ## CASE 2: element-wise comparison
             ## if there are floating elements
-            ## use `decimal` library for good floating point comparision
+            ## use `decimal` library for good floating point comparison
             ## otherwise gotcha: np.isclose(50000000000000000, 50000000000000001) = True
             ## note that we should always be able to convert to decimals
 


### PR DESCRIPTION
## Summary
- update README flag instructions
- clarify the Test operator's description
- allow enum or string input in `extract_test_cases_from_jsonl`
- fix spelling of "comparison" in the evaluation helper
- rename evaluation helper to avoid pytest collection
- remove extra test config and sample tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875aa3d8dc08329a7f0ad028fb447fb